### PR TITLE
Added support to indentation on Gherkin strings

### DIFF
--- a/Sources/Gherkin/Parser.swift
+++ b/Sources/Gherkin/Parser.swift
@@ -34,7 +34,7 @@ func makeParser() -> GherkinConsumer {
     let feature: GherkinConsumer = makeLabelAndDescription(startText: "Feature:", ignoreText: "Scenario:" | "Scenario Outline:" | ["@", text])
 
     let stepKeywords: GherkinConsumer = .sequence([whitespace, "Given" | "When" | "Then" | "And" | "But"])
-    let step: GherkinConsumer = .label(.step, [whitespace, stepKeywords, whitespace, text, newLines])
+    let step: GherkinConsumer = .label(.step, [stepKeywords, whitespace, text, newLines])
 
     let scenarioName: GherkinConsumer = makeLabelAndDescription(startText: "Scenario:", ignoreText: stepKeywords)
     let scenario: GherkinConsumer = .label(.scenario, [

--- a/Sources/Gherkin/Parser.swift
+++ b/Sources/Gherkin/Parser.swift
@@ -33,8 +33,8 @@ func makeParser() -> GherkinConsumer {
 
     let feature: GherkinConsumer = makeLabelAndDescription(startText: "Feature:", ignoreText: "Scenario:" | "Scenario Outline:" | ["@", text])
 
-    let stepKeywords: GherkinConsumer = "Given" | "When" | "Then" | "And" | "But"
-    let step: GherkinConsumer = .label(.step, [stepKeywords, whitespace, text, newLines])
+    let stepKeywords: GherkinConsumer = .sequence([whitespace, "Given" | "When" | "Then" | "And" | "But"])
+    let step: GherkinConsumer = .label(.step, [whitespace, stepKeywords, whitespace, text, newLines])
 
     let scenarioName: GherkinConsumer = makeLabelAndDescription(startText: "Scenario:", ignoreText: stepKeywords)
     let scenario: GherkinConsumer = .label(.scenario, [
@@ -47,11 +47,13 @@ func makeParser() -> GherkinConsumer {
     let discardedPipe: GherkinConsumer = .discard("|")
 
     let tableRow: GherkinConsumer = [
+        whitespace,
         .interleaved(discardedPipe, text),
         newLines,
     ]
 
     let example: GherkinConsumer = [
+        whitespace,
         .discard("Examples:"),
         newLines,
         .label(.exampleKeys, tableRow),

--- a/Tests/GherkinTests/GherkinTests.swift
+++ b/Tests/GherkinTests/GherkinTests.swift
@@ -295,6 +295,7 @@ final class SwiftGherkinTests: XCTestCase {
 
     static var allTests = [
         ("testParsingSimpleFeatureFile", testParsingSimpleFeatureFile),
+        ("testParsingSimpleFeatureFileWithIndentation", testParsingSimpleFeatureFileWithIndentation),
         ("testParsingSimpleFeatureFileWithTag", testParsingSimpleFeatureFileWithTag),
         ("testParsingSimpleFeatureFileWithMultipleTags", testParsingSimpleFeatureFileWithMultipleTags),
         ("testParsingSimpleFeatureFileWithVariable", testParsingSimpleFeatureFileWithVariable),
@@ -303,6 +304,7 @@ final class SwiftGherkinTests: XCTestCase {
         ("testParsingFeatureFileWithMultiLineDescription", testParsingFeatureFileWithMultiLineDescription),
         ("testParsingFeatureFileWithScenarioDescription", testParsingFeatureFileWithScenarioDescription),
         ("testParsingSimpleFeatureFileWithVariable", testParsingSimpleFeatureFileWithVariable),
+        ("testParsingSimpleFeatureFileWithVariableWithIndentation", testParsingSimpleFeatureFileWithVariableWithIndentation),
         ("testParsingSimpleFeatureFileWithMultipleVariable", testParsingSimpleFeatureFileWithMultipleVariable),
         ("testParsingSimpleFeatureFileWithMultipleVariableAndTag", testParsingSimpleFeatureFileWithMultipleVariableAndTag),
         ("testParsingSimpleFeatureFileWithMultipleVariableAndTags", testParsingSimpleFeatureFileWithMultipleVariableAndTags)

--- a/Tests/GherkinTests/GherkinTests.swift
+++ b/Tests/GherkinTests/GherkinTests.swift
@@ -19,6 +19,23 @@ final class SwiftGherkinTests: XCTestCase {
         XCTAssertTrue(result.scenarios.first?.steps[0].text == "I am a mountain")
         XCTAssertEqual(result.scenarios[0].name, "minimalistic")
     }
+    
+    func testParsingSimpleFeatureFileWithIndentation() throws {
+        let text = """
+        Feature: Minimal Scenario Outline
+
+        Scenario: minimalistic
+            Given I am a mountain
+            And I love chocolate
+        """
+        
+        let result = try Feature(text)
+        XCTAssertEqual(result.name, "Minimal Scenario Outline")
+        XCTAssertTrue(result.scenarios.count == 1)
+        XCTAssertTrue(result.scenarios.first?.steps.count == 2)
+        XCTAssertTrue(result.scenarios.first?.steps[0].text == "I am a mountain")
+        XCTAssertEqual(result.scenarios[0].name, "minimalistic")
+    }
 
     func testParsingSimpleFeatureFileWithTag() throws {
         let text = """
@@ -151,6 +168,35 @@ final class SwiftGherkinTests: XCTestCase {
         XCTAssertEqual(result.scenarios[0].examples!.count, 5)
         XCTAssertEqual(result.scenarios[0].examples![0].values, ["mountain": "etna"])
 
+        let json = try JSONEncoder().encode(result)
+        XCTAssertNotNil(json)
+    }
+    
+    func testParsingSimpleFeatureFileWithVariableWithIndentation() throws {
+        let text = """
+        Feature: Minimal Scenario Outline
+
+        Scenario Outline: minimalistic
+            Given I am a <mountain>
+            And I love chocolate
+
+            Examples:
+                | mountain |
+                | etna     |
+                | another  |
+                | another  |
+                | another  |
+                | another  |
+        """
+        
+        let result = try Feature(text)
+        XCTAssertEqual(result.name, "Minimal Scenario Outline")
+        XCTAssertTrue(result.scenarios.count == 1)
+        XCTAssertTrue(result.scenarios.first?.steps.count == 2)
+        XCTAssertEqual(result.scenarios[0].steps[0].text, "I am a <mountain>")
+        XCTAssertEqual(result.scenarios[0].examples!.count, 5)
+        XCTAssertEqual(result.scenarios[0].examples![0].values, ["mountain": "etna"])
+        
         let json = try JSONEncoder().encode(result)
         XCTAssertNotNil(json)
     }


### PR DESCRIPTION
Given that the gherkin language allows indentation this PR is to consent to the parser to read also gherkin files that contains indentation

e.g.

```gherkin
Feature: Minimal Scenario Outline
Scenario Outline: minimalistic
   Given I am a <mountain>
   And I love chocolate
   Examples:
      | mountain |
      | etna     |
      | another  |
      | another  |
      | another  |
      | another  |
```