### PR TITLE
Adds support to Tags before Feature

### DIFF
--- a/Sources/Gherkin/Models.swift
+++ b/Sources/Gherkin/Models.swift
@@ -26,7 +26,7 @@ public struct Feature: Codable {
             throw GherkinError.standard
         }
         
-        let updatedScenarios: [Scenario] = result.scenarios.compactMap { scenario in
+        let updatedScenarios: [Scenario] = result.scenarios.flatMap { scenario in
             var finalScenario: Scenario
             
             switch scenario {
@@ -191,6 +191,10 @@ public struct Tag: Codable, Hashable {
 
     public init(_ name: String) {
         self.name = name
+    }
+    
+    public var hashValue: Int {
+        return name.hashValue
     }
 }
 

--- a/Sources/Gherkin/Models.swift
+++ b/Sources/Gherkin/Models.swift
@@ -12,11 +12,13 @@ public struct Feature: Codable {
     public var name: String
     public var textDescription: String?
     public var scenarios: [Scenario]
+    public var tags: [Tag]?
 
-    public init(name: String, description: String?, scenarios: [Scenario]) {
+    public init(name: String, description: String?, scenarios: [Scenario], tags: [Tag]? = nil) {
         self.name = name
         textDescription = description
         self.scenarios = scenarios
+        self.tags = tags
     }
 
     public init(_ string: String) throws {
@@ -27,6 +29,7 @@ public struct Feature: Codable {
         name = result.name
         textDescription = result.textDescription
         scenarios = result.scenarios
+        tags = result.tags
     }
 
     public init(_ data: Data) throws {

--- a/Sources/Gherkin/Models.swift
+++ b/Sources/Gherkin/Models.swift
@@ -25,16 +25,55 @@ public struct Feature: Codable {
         guard let result = try gherkin.match(string).transform(_transform) as? Feature else {
             throw GherkinError.standard
         }
-
+        
+        let updatedScenarios: [Scenario] = result.scenarios.compactMap { scenario in
+            var finalScenario: Scenario
+            
+            switch scenario {
+            case let .simple(simpleScenario):
+                finalScenario = Feature.include(featureTags: result.tags, on: simpleScenario)
+            case let .outline(outlineScenario):
+                finalScenario = Feature.include(featureTags: result.tags, on: outlineScenario)
+            }
+            
+            return finalScenario
+        }
+        
         name = result.name
         textDescription = result.textDescription
-        scenarios = result.scenarios
+        scenarios = updatedScenarios
         tags = result.tags
     }
 
     public init(_ data: Data) throws {
         guard let text = String(data: data, encoding: .utf8) else { throw GherkinError.standard }
         try self.init(text)
+    }
+    
+    private static func include(featureTags: [Tag]?, on simpleScenario: ScenarioSimple) -> Scenario {
+        let newTags = merge(featureTags: featureTags, and: simpleScenario.tags)
+        
+        let newScenario = ScenarioSimple(name: simpleScenario.name,
+                                         description: simpleScenario.textDescription,
+                                         steps: simpleScenario.steps,
+                                         tags: newTags)
+        return Scenario.simple(newScenario)
+    }
+    
+    private static func include(featureTags: [Tag]?, on outlineScenario: ScenarioOutline) -> Scenario {
+        let newTags = merge(featureTags: featureTags, and: outlineScenario.tags)
+        
+        let newScenario = ScenarioOutline(name: outlineScenario.name,
+                                          description: outlineScenario.textDescription,
+                                          steps: outlineScenario.steps,
+                                          examples: outlineScenario.examples,
+                                          tags: newTags)
+        return Scenario.outline(newScenario)
+    }
+    
+    private static func merge(featureTags: [Tag]?, and scenarioTags: [Tag]?) -> [Tag]? {
+        let setTag: Set<Tag> = Set((featureTags ?? []) + (scenarioTags ?? []))
+        return Array(setTag).sorted { $0.name < $1.name }
     }
 }
 
@@ -147,7 +186,7 @@ public struct Step: Codable {
     }
 }
 
-public struct Tag: Codable {
+public struct Tag: Codable, Hashable {
     public let name: String
 
     public init(_ name: String) {

--- a/Sources/Gherkin/Models.swift
+++ b/Sources/Gherkin/Models.swift
@@ -196,6 +196,10 @@ public struct Tag: Codable, Hashable {
     public var hashValue: Int {
         return name.hashValue
     }
+    
+    public static func == (lhs: Tag, rhs: Tag) -> Bool {
+        return lhs.name == rhs.name
+    }
 }
 
 /// The Step name

--- a/Sources/Gherkin/Parser.swift
+++ b/Sources/Gherkin/Parser.swift
@@ -71,6 +71,7 @@ func makeParser() -> GherkinConsumer {
 
     let anyScenario: GherkinConsumer = scenario | scenarioOutline
     let gherkin: GherkinConsumer = .label(.feature, [
+        .zeroOrMore(tag),
         feature,
         .oneOrMore(anyScenario),
     ])

--- a/Sources/Gherkin/Transform.swift
+++ b/Sources/Gherkin/Transform.swift
@@ -11,11 +11,13 @@ import Foundation
 func _transform(label: GherkinLabel, values: [Any]) -> Any? {
     switch label {
     case .feature:
-        guard let name = values.first as? String else { return nil }
+        let strings: [String] = filterd(values, is: String.self)!
+        guard let name = strings.first as? String else { return nil }
         var description: String? = values.safely(1) as? String ?? nil
         description?.trimWhitespace()
         let scenarios: [Scenario] = filterd(values, is: Scenario.self)!
-        let feature = Feature(name: name, description: description, scenarios: scenarios)
+        let tags: [Tag]? = filterd(values, is: Tag.self)
+        let feature = Feature(name: name, description: description, scenarios: scenarios, tags: tags)
         return feature
     case .step:
         let name = StepName(rawValue: (values[0] as! String).lowercased())!

--- a/Tests/GherkinTests/GherkinTests.swift
+++ b/Tests/GherkinTests/GherkinTests.swift
@@ -380,7 +380,7 @@ final class SwiftGherkinTests: XCTestCase {
         XCTAssertTrue(result.scenarios.first?.steps.count == 2)
         XCTAssertTrue(result.scenarios.first?.steps[0].text == "I am a mountain")
         XCTAssertEqual(result.scenarios[0].name, "minimalistic")
-        XCTAssertEqual(result.scenarios[0].tags!.map { $0.name }, ["testTag2", "testTag3"])
+        XCTAssertEqual(result.scenarios[0].tags!.map { $0.name }, ["testTag", "testTag2", "testTag3"])
     }
 
     func testCreatingAFeatureInCode() {


### PR DESCRIPTION
According to the [definition](https://en.wikipedia.org/wiki/Cucumber_(software)#Gherkin_language) of Tags on the Gherkin syntax:

> Tags
> Gherkin's Feature structure forces organisation. However, in cases where this default organisation is inconvenient or insufficient, Gherkin provides Tags. Tags are @-prefixed strings and can be placed before
> 
> Feature
> Scenario
> Scenario Outline
> Examples
> An element can have multiple tags and inherits from parent elements.

So I create the support to tags before Features, also I made the Scenario tags inherit from Features' tag. 

I didn't create the Examples tags because I couldn't find any example of how it works or looks like.

Also to make sure there are no duplicate tags on a Scenario, I had to create a Set and then back to Array, to be more testable and avoid the randomness I sorted the array. Since the tags have no particular order, it won't affect in real case scenarios, and I didn't want to introduce any breaking changes changing it to Set<Tag>